### PR TITLE
Fix spelling errors.

### DIFF
--- a/Real/real.pd
+++ b/Real/real.pd
@@ -3243,7 +3243,7 @@ manner.
             eigenvalues are computed to high relative accuracy when
             possible in future releases.  The current code does not
             make any guarantees about high relative accuracy, but
-            furure releases will. See J. Barlow and J. Demmel,
+            future releases will. See J. Barlow and J. Demmel,
             "Computing Accurate Eigensystems of Scaled Diagonally
             Dominant Matrices", LAPACK Working Note #7, for a discussion
             of which matrices define their eigenvalues to high relative
@@ -5352,7 +5352,7 @@ Solve the BLS using a divide and conquer approach.
 
 =item 3
 
-Apply back all the Householder tranformations to solve
+Apply back all the Householder transformationss to solve
 the original least squares problem.
 
 =back
@@ -10532,7 +10532,7 @@ pp_def("laswp",
 
 Performs a series of row interchanges on the matrix A.   
 One row interchange is initiated for each of rows k1 through k2 of A.
-Dosen\'t use PDL indice (start = 1).   
+Doesn\'t use PDL indice (start = 1).   
 
     Arguments   
     =========   

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -5352,7 +5352,7 @@ Solve the BLS using a divide and conquer approach.
 
 =item 3
 
-Apply back all the Householder transformationss to solve
+Apply back all the Householder transformations to solve
 the original least squares problem.
 
 =back
@@ -10532,7 +10532,7 @@ pp_def("laswp",
 
 Performs a series of row interchanges on the matrix A.   
 One row interchange is initiated for each of rows k1 through k2 of A.
-Doesn\'t use PDL indice (start = 1).   
+Doesn\'t use PDL indices (start = 1).
 
     Arguments   
     =========   

--- a/Trans/trans.pd
+++ b/Trans/trans.pd
@@ -388,7 +388,7 @@ pp_def('geexp',
 Computes exp(t*A), the matrix exponential of a general matrix,
 using the irreducible rational Pade approximation to the 
 exponential function exp(x) = r(x) = (+/-)( I + 2*(q(x)/p(x)) ), 
-combined with scaling-and-squaring and optionaly normalization of the trace.
+combined with scaling-and-squaring and optionally normalization of the trace.
 The algorithm is described in Roger B. Sidje (rbs@maths.uq.edu.au)
 "EXPOKIT: Software Package for Computing Matrix Exponentials".
 ACM - Transactions On Mathematical Software, 24(1):130-156, 1998

--- a/lib/PDL/LinearAlgebra/Special.pm
+++ b/lib/PDL/LinearAlgebra/Special.pm
@@ -41,7 +41,7 @@ This module provides some constructors of well known matrices.
 
 =for ref
 
-Contruct Hilbert matrix from specifications list or template ndarray
+Construct Hilbert matrix from specifications list or template ndarray
 
 =for usage
 
@@ -177,7 +177,7 @@ For complex, needs object of type PDL::Complex.
 
  mhankel(c,r), where c and r are vectors, returns matrix whose first column 
  is c and whose last row is r. The last element of c prevails.
- mhankel(c) returns matrix whith element below skew diagonal (anti-diagonal) equals
+ mhankel(c) returns matrix with element below skew diagonal (anti-diagonal) equals
  to zero. If c is a scalar number, make it from sequence beginning at one.
 
 =for ref


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * tranformations -> transformationss
 * Dosen't        -> Doesn't
 * Contruct       -> Construct
 * whith          -> with
 * furure         -> future
 * optionaly      -> optionally
 
 Note that the patches for these were initially forwarded to RT and SourceForge:

 https://rt.cpan.org/Ticket/Display.html?id=106790
 https://sourceforge.net/p/pdl/patches/82/