### PR TITLE
Small fix to Special.pm synopsis and UTF-8 conversions (lib directory)

### DIFF
--- a/lib/PDL/LinearAlgebra.pm
+++ b/lib/PDL/LinearAlgebra.pm
@@ -46,7 +46,7 @@ our @ISA = @ISA ? @ISA : 'PDL'; # so still operates when no PDL::Complex
 }
 ########################################################################
 
-=encoding Latin-1
+=encoding utf8
 
 =head1 NAME
 
@@ -3376,7 +3376,7 @@ sub PDL::mgsvd {
 
 =head1 AUTHOR
 
-Copyright (C) Grégory Vanuxem 2005-2018.
+Copyright (C) GrÃ©gory Vanuxem 2005-2018.
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the Perl Artistic License as in the file Artistic_2

--- a/lib/PDL/LinearAlgebra/Special.pm
+++ b/lib/PDL/LinearAlgebra/Special.pm
@@ -19,7 +19,7 @@ our @ISA = ( 'PDL::Exporter');
 
 use strict;
 
-=encoding Latin-1
+=encoding utf8
 
 =head1 NAME
 
@@ -327,7 +327,7 @@ sub PDL::mcompanion{
 
 =head1 AUTHOR
 
-Copyright (C) Grégory Vanuxem 2005-2007.
+Copyright (C) GrÃ©gory Vanuxem 2005-2007.
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the artistic license as specified in the Artistic

--- a/lib/PDL/LinearAlgebra/Special.pm
+++ b/lib/PDL/LinearAlgebra/Special.pm
@@ -27,7 +27,7 @@ PDL::LinearAlgebra::Special - Special matrices for PDL
 
 =head1 SYNOPSIS
 
- use PDL::LinearAlgebra::Mtype;
+ use PDL::LinearAlgebra::Special;
 
  $a = mhilb(5,5);
 


### PR DESCRIPTION
 - Mtype => Special
 - Switch purely coded Perl files in /lib directory to UTF-8 encoding