### PR TITLE
make parameter 'uplo' optional for [c]tricpy

### DIFF
--- a/Complex/complex.pd
+++ b/Complex/complex.pd
@@ -4947,9 +4947,11 @@ EOF
 ################################################################################
 pp_def(
 	'ctricpy',
-	Pars => 'A(c=2,m,n);int uplo();[o] C(c=2,m,n)',
+	Pars => 'A(c=2,m,n);[o] C(c=2,m,n)',
+	OtherPars => 'int uplo',
+	ArgOrder => 1,
 	Code => '
-		if ($uplo())
+		if ($COMP(uplo))
 		{
 			loop (n,m) %{
 				loop(c) %{ $C() = $A(); %}
@@ -4970,7 +4972,9 @@ pp_def(
 
 =for ref
 
-Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
+Copy triangular part to another matrix.
+The parameters order is A, uplo, C.
+If uplo == 0 (which is the default), copy upper triangular part.
 
 =cut
 

--- a/Complex/complex.pd
+++ b/Complex/complex.pd
@@ -4949,32 +4949,49 @@ pp_def(
 	'ctricpy',
 	Pars => 'A(c=2,m,n);[o] C(c=2,m,n)',
 	OtherPars => 'int uplo',
-	ArgOrder => 1,
+	OtherParsDefaults => {uplo => 0},
+	ArgOrder => [qw(A uplo C)],
 	Code => '
 		if ($COMP(uplo))
 		{
-			loop (n,m) %{
-				loop(c) %{ $C() = $A(); %}
-				if (m >= n) break;
+			broadcastloop %{
+				loop (n,m) %{
+					loop(c) %{ $C() = $A(); %}
+					if (m >= n) break;
+				%}
 			%}
 		}
 		else
 		{
-			loop (m,n) %{
-				loop(c) %{ $C() = $A(); %}
-				if (n >= m) break;
+			broadcastloop %{
+				loop (m,n) %{
+					loop(c) %{ $C() = $A(); %}
+					if (n >= m) break;
+				%}
 			%}
 		}
 		
 
 	',
 	Doc => <<EOT
+=for usage
+
+ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
+
+=for examples
+
+	use PDL::LinearAlgebra;
+
+	\$c = \$a->ctricpy(\$uplo);	# explicit uplo
+	\$c = \$a->ctricpy;			# default to upper
+or
+	use PDL::LinearAlgebra::Complex;
+
+	ctricpy(\$a, \$uplo, \$c);	# modify c
 
 =for ref
 
-Copy triangular part to another matrix.
-The parameters order is A, uplo, C.
-If uplo == 0 (which is the default), copy upper triangular part.
+Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
 
 =cut
 

--- a/Complex/complex.pd
+++ b/Complex/complex.pd
@@ -4973,7 +4973,7 @@ pp_def(
 		
 
 	',
-	Doc => <<EOT
+	Doc => <<'EOT'
 =for usage
 
 ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
@@ -4982,12 +4982,12 @@ ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
 
 	use PDL::LinearAlgebra;
 
-	\$c = \$a->ctricpy(\$uplo);	# explicit uplo
-	\$c = \$a->ctricpy;			# default to upper
+	$c = $a->ctricpy($uplo);	# explicit uplo
+	$c = $a->ctricpy;			# default to upper
 or
 	use PDL::LinearAlgebra::Complex;
 
-	ctricpy(\$a, \$uplo, \$c);	# modify c
+	ctricpy($a, $uplo, $c);	# modify c
 
 =for ref
 

--- a/Complex/complex.pd
+++ b/Complex/complex.pd
@@ -4970,34 +4970,30 @@ pp_def(
 				%}
 			%}
 		}
-		
-
 	',
-	Doc => <<'EOT'
-=for usage
-
-ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
-
-=for examples
-
-	use PDL::LinearAlgebra;
-
-	$c = $a->ctricpy($uplo);	# explicit uplo
-	$c = $a->ctricpy;			# default to upper
-or
-	use PDL::LinearAlgebra::Complex;
-
-	ctricpy($a, $uplo, $c);	# modify c
-
-=for ref
-
-Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
-
-=cut
-
-EOT
-
+	Doc => undef
 );
+
+#=for usage
+#
+#ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
+#
+#=for examples
+#
+#	use PDL::LinearAlgebra;
+#
+#	$c = $a->ctricpy($uplo);	# explicit uplo
+#	$c = $a->ctricpy;			# default to upper
+#or
+#	use PDL::LinearAlgebra::Complex;
+#
+#	ctricpy($a, $uplo, $c);	# modify c
+#
+#=for ref
+#
+#Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
+#
+#=cut
 
 pp_bless('PDL');
 pp_def(

--- a/Complex/complex.pd
+++ b/Complex/complex.pd
@@ -4974,27 +4974,6 @@ pp_def(
 	Doc => undef
 );
 
-#=for usage
-#
-#ctricpy(PDL::Complex(A), int(uplo), PDL::Complex(C))
-#
-#=for examples
-#
-#	use PDL::LinearAlgebra;
-#
-#	$c = $a->ctricpy($uplo);	# explicit uplo
-#	$c = $a->ctricpy;			# default to upper
-#or
-#	use PDL::LinearAlgebra::Complex;
-#
-#	ctricpy($a, $uplo, $c);	# modify c
-#
-#=for ref
-#
-#Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
-#
-#=cut
-
 pp_bless('PDL');
 pp_def(
 	'cmstack',

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -10475,7 +10475,7 @@ the exponent range, as is found on a Cray.
 ################################################################################
 pp_def(
 	'tricpy',
-	Pars => 'complex A(m,n);complex [o] C(m,n)',
+	Pars => 'A(m,n);[o] C(m,n)',
 	OtherPars => 'int uplo',
 	OtherParsDefaults => {uplo => 0},
 	ArgOrder => [qw(A uplo C)],

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -10477,9 +10477,13 @@ the exponent range, as is found on a Cray.
 pp_def(
 	'tricpy',
 	Pars => 'A(m,n);int uplo();[o] C(m,n)',
+	Pars => 'A(m,n);[o] C(m,n)',
+    OtherPars => 'int uplo',
+    OtherParsDefaults => {uplo => 0},
+    ArgOrder => 1,
 	GenericTypes => [ppdefs_all()],
 	Code => '
-		if ($uplo())
+		if ($COMP(uplo))
 		{
 			loop(n,m) %{
 				$C() = $A();
@@ -10497,7 +10501,9 @@ pp_def(
 	Doc => <<EOT
 =for ref
 
-Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
+Copy triangular part to another matrix.
+The parameters order is A, uplo, C.
+If uplo == 0 (which is the default), copy upper triangular part.
 
 =cut
 

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -10500,7 +10500,7 @@ pp_def(
 			%}
 		}
 	',
-	Doc => <<EOT
+	Doc => <<'EOT'
 =for usage
 
 tricpy(PDL(A), int(uplo), PDL(C))
@@ -10509,12 +10509,12 @@ tricpy(PDL(A), int(uplo), PDL(C))
 
 	use PDL::LinearAlgebra;
 
-	\$c = \$a->tricpy(\$uplo);	# explicit uplo
-	\$c = \$a->tricpy;			# default upper
+	$c = $a->tricpy($uplo);	# explicit uplo
+	$c = $a->tricpy;			# default upper
 or
 	use PDL::LinearAlgebra::Real;
 
-	tricpy(\$a, $uplo, \$c);	# modify c
+	tricpy($a, $uplo, $c);	# modify c
 
 =for ref
 

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -10505,7 +10505,7 @@ pp_def(
 
 tricpy(PDL(A), int(uplo), PDL(C))
 
-=for examples
+=for example
 
 	use PDL::LinearAlgebra;
 

--- a/Real/real.pd
+++ b/Real/real.pd
@@ -10473,44 +10473,58 @@ the exponent range, as is found on a Cray.
 #		OTHER AUXILIARY ROUTINES
 #
 ################################################################################
-
 pp_def(
 	'tricpy',
-	Pars => 'A(m,n);int uplo();[o] C(m,n)',
-	Pars => 'A(m,n);[o] C(m,n)',
-    OtherPars => 'int uplo',
-    OtherParsDefaults => {uplo => 0},
-    ArgOrder => 1,
+	Pars => 'complex A(m,n);complex [o] C(m,n)',
+	OtherPars => 'int uplo',
+	OtherParsDefaults => {uplo => 0},
+	ArgOrder => [qw(A uplo C)],
 	GenericTypes => [ppdefs_all()],
 	Code => '
 		if ($COMP(uplo))
 		{
-			loop(n,m) %{
-				$C() = $A();
-				if (m >= n) break;
+			broadcastloop %{
+				loop(n,m) %{
+					$C() = $A();
+					if (m >= n) break;
+				%}
 			%}
 		}
 		else
 		{
-			loop(m,n) %{
-				$C() = $A();
-				if (n >= m) break;
+			broadcastloop %{
+				loop(m,n) %{
+					$C() = $A();
+					if (n >= m) break;
+				%}
 			%}
 		}
 	',
 	Doc => <<EOT
+=for usage
+
+tricpy(PDL(A), int(uplo), PDL(C))
+
+=for examples
+
+	use PDL::LinearAlgebra;
+
+	\$c = \$a->tricpy(\$uplo);	# explicit uplo
+	\$c = \$a->tricpy;			# default upper
+or
+	use PDL::LinearAlgebra::Real;
+
+	tricpy(\$a, $uplo, \$c);	# modify c
+
 =for ref
 
-Copy triangular part to another matrix.
-The parameters order is A, uplo, C.
-If uplo == 0 (which is the default), copy upper triangular part.
+Copy triangular part to another matrix. If uplo == 0 copy upper triangular part.
 
 =cut
 
 EOT
 
 );
-
 
 pp_def(
 	'cplx_eigen',

--- a/t/1.t
+++ b/t/1.t
@@ -81,11 +81,9 @@ $B = identity(2);
 ok fapprox($got = $A x $B, $A), 'complex first' or diag "got: $got";
 ok fapprox($got = $B x $A, $A), 'complex second' or diag "got: $got";
 
-$A = random(4, 4);
-my $up = $A->copy;
-$up->where(sequence(4) < sequence(1,4)) .= 0;
-my $lo = $A->copy;
-$lo->where(sequence(4) > sequence(1,4)) .= 0;
+$A = pdl '[[1 2 3] [4 5 6] [7 8 9]]';
+my $up = pdl '[[1 2 3] [0 5 6] [0 0 9]]';
+my $lo = pdl '[[1 0 0] [4 5 0] [7 8 9]]';
 ok fapprox($got = $A->tricpy(0), $up), 'upper triangle #1' or diag "got: $got";
 tricpy($A, 0, $got = null);
 ok fapprox($got, $up), 'upper triangle #2' or diag "got: $got";

--- a/t/1.t
+++ b/t/1.t
@@ -81,4 +81,17 @@ $B = identity(2);
 ok fapprox($got = $A x $B, $A), 'complex first' or diag "got: $got";
 ok fapprox($got = $B x $A, $A), 'complex second' or diag "got: $got";
 
+$A = sequence(4, 4);
+my $up = $A->copy;
+$up->where(sequence(4) < sequence(1,4)) .= 0;
+my $lo = $A->copy;
+$lo->where(sequence(4) > sequence(1,4)) .= 0;
+ok fapprox($got = $A->tricpy(0), $up), 'upper triangle #1' or diag "got: $got";
+tricpy($A, 0, my $C = null);
+ok fapprox($C, $up), 'upper triangle #2' or diag "got: $C";
+ok fapprox($got = $A->tricpy, $up), 'upper triangle #3' or diag "got: $got";
+ok fapprox($got = $A->tricpy(1), $lo), 'lower triangle #1' or diag "got: $got";
+tricpy($A, 1, $C = null);
+ok fapprox($C, $lo), 'lower triangle #2' or diag "got: $C";
+
 done_testing;

--- a/t/1.t
+++ b/t/1.t
@@ -81,17 +81,17 @@ $B = identity(2);
 ok fapprox($got = $A x $B, $A), 'complex first' or diag "got: $got";
 ok fapprox($got = $B x $A, $A), 'complex second' or diag "got: $got";
 
-$A = sequence(4, 4);
+$A = random(4, 4);
 my $up = $A->copy;
 $up->where(sequence(4) < sequence(1,4)) .= 0;
 my $lo = $A->copy;
 $lo->where(sequence(4) > sequence(1,4)) .= 0;
 ok fapprox($got = $A->tricpy(0), $up), 'upper triangle #1' or diag "got: $got";
-tricpy($A, 0, my $C = null);
-ok fapprox($C, $up), 'upper triangle #2' or diag "got: $C";
+tricpy($A, 0, $got = null);
+ok fapprox($got, $up), 'upper triangle #2' or diag "got: $got";
 ok fapprox($got = $A->tricpy, $up), 'upper triangle #3' or diag "got: $got";
 ok fapprox($got = $A->tricpy(1), $lo), 'lower triangle #1' or diag "got: $got";
-tricpy($A, 1, $C = null);
-ok fapprox($C, $lo), 'lower triangle #2' or diag "got: $C";
+tricpy($A, 1, $got = null);
+ok fapprox($got, $lo), 'lower triangle #2' or diag "got: $got";
 
 done_testing;

--- a/t/legacy.t
+++ b/t/legacy.t
@@ -37,9 +37,10 @@ EOF
 runtest($aa, '_norm', $aa_exp->abs, [1]);
 runtest($aa, '_norm', $aa_exp->t, [0,1]);
 
-$aa = random(2, 3, 3)->cplx;
-my $up = ones(3, 3)->tricpy(0) * $aa;
-my $lo = ones(3, 3)->tricpy(1) * $aa;
+$aa = pdl('[[[0 1] [2 3] [4 5]] [[6  7] [8  9] [10 11]] [[12 13] [14 15] [16 17]]] ')->cplx;
+my $up = pdl('[[[0 1] [2 3] [4 5]] [[0  0] [8  9] [10 11]] [[0 0] [0 0] [16 17]]]')->cplx;
+my $lo = pdl('[[[0 1] [0 0] [0 0]] [[6  7] [8  9] [0 0]] [[12 13] [14 15] [16 17]]]')->cplx;
+
 runtest($aa, 'ctricpy', $up, [0]);
 runtest($aa, 'ctricpy', $up);
 runtest($aa, 'ctricpy', $lo, [1]);

--- a/t/legacy.t
+++ b/t/legacy.t
@@ -37,7 +37,7 @@ EOF
 runtest($aa, '_norm', $aa_exp->abs, [1]);
 runtest($aa, '_norm', $aa_exp->t, [0,1]);
 
-$aa = sequence(2, 3, 3)->cplx;
+$aa = random(2, 3, 3)->cplx;
 my $up = ones(3, 3)->tricpy(0) * $aa;
 my $lo = ones(3, 3)->tricpy(1) * $aa;
 runtest($aa, 'ctricpy', $up, [0]);

--- a/t/legacy.t
+++ b/t/legacy.t
@@ -37,6 +37,13 @@ EOF
 runtest($aa, '_norm', $aa_exp->abs, [1]);
 runtest($aa, '_norm', $aa_exp->t, [0,1]);
 
+$aa = sequence(2, 3, 3)->cplx;
+my $up = ones(3, 3)->tricpy(0) * $aa;
+my $lo = ones(3, 3)->tricpy(1) * $aa;
+runtest($aa, 'ctricpy', $up, [0]);
+runtest($aa, 'ctricpy', $up);
+runtest($aa, 'ctricpy', $lo, [1]);
+
 do './t/common.pl'; die if $@;
 
 done_testing;


### PR DESCRIPTION
Enable calling `$m->tricpy()` to extract an upper triangular matrix as discussed at [PerlMonks](https://perlmonks.org/index.pl?node_id=11157483)

This change will silently break code like
```
sequence(3,3,2)->tricpy(indx(1, 0))
```